### PR TITLE
Compiling protograph templates into native functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM java:8
 WORKDIR /
-ADD target/protograph-0.0.16-standalone.jar protograph.jar
+ADD target/protograph-0.0.17-standalone.jar protograph.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM java:8
 WORKDIR /
-ADD target/protograph-0.0.17-standalone.jar protograph.jar
+ADD target/protograph-0.0.19-standalone.jar protograph.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM java:8
 WORKDIR /
-ADD target/protograph-0.0.20-standalone.jar protograph.jar
+ADD target/protograph-0.0.21-standalone.jar protograph.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM java:8
 WORKDIR /
-ADD target/protograph-0.0.19-standalone.jar protograph.jar
+ADD target/protograph-0.0.20-standalone.jar protograph.jar

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [cheshire "5.7.1"]
+                 [instaparse "1.4.8"]
                  [io.forward/yaml "1.0.6"]
                  [com.taoensso/timbre "4.8.0"]
                  [selmer "1.10.8"]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,6 @@
                  [instaparse "1.4.8"]
                  [io.forward/yaml "1.0.6"]
                  [com.taoensso/timbre "4.8.0"]
-                 [selmer "1.10.8"]
                  [clojurewerkz/propertied "1.2.0"]
                  [org.apache.kafka/kafka_2.11 "0.10.0.1"]]
   :repositories [["sonatype snapshots"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protograph "0.0.19"
+(defproject protograph "0.0.20"
   :description "tranform a stream of messages into a graph"
   :url "http://github.com/bmeg/protograph"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protograph "0.0.16"
+(defproject protograph "0.0.17"
   :description "tranform a stream of messages into a graph"
   :url "http://github.com/bmeg/protograph"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protograph "0.0.17"
+(defproject protograph "0.0.18"
   :description "tranform a stream of messages into a graph"
   :url "http://github.com/bmeg/protograph"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protograph "0.0.20"
+(defproject protograph "0.0.21"
   :description "tranform a stream of messages into a graph"
   :url "http://github.com/bmeg/protograph"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protograph "0.0.18"
+(defproject protograph "0.0.19"
   :description "tranform a stream of messages into a graph"
   :url "http://github.com/bmeg/protograph"
   :license {:name "Eclipse Public License"

--- a/src/protograph/compile.clj
+++ b/src/protograph/compile.clj
@@ -1,0 +1,79 @@
+(ns protograph.compile
+  (:require
+   [clojure.string :as string]
+   [instaparse.core :as parse]))
+
+(def parser-spec
+  "field = constant (template constant)*
+   constant = #'[^{}]'*
+   template = '{{' expression '}}'
+   expression = accessor (pipe function)*
+   accessor = index (dot index)*
+   index = #'[a-zA-Z0-9_,!@#$%^&*?\\-]'+
+   function = index (colon argument)*
+   argument = #'[^{}]'*
+   colon = ':'
+   dot = '.'
+   pipe = '|'")
+
+(def field-parser
+  (parse/parser parser-spec))
+
+(declare compile-switch)
+
+(defn compile-field
+  [terms]
+  (map compile-switch terms))
+
+(defn compile-expression
+  [terms]
+  (let [accessor (compile-switch (first terms))
+        functions (filter (fn [i] (= :function (first i))) (rest terms))
+        functions (map compile-switch functions)]
+    [accessor functions]
+    (fn [m]
+      (apply comp (reverse (map (fn [f] (partial f m)) functions))))))
+
+(defn compile-accessor
+  [terms]
+  (let [indexes (filter (fn [i] (= :index (first i))) terms)
+        indexes (map compile-switch indexes)]
+    [:get-in :m indexes]
+    (fn [m] (get-in m indexes))))
+
+(defn compile-function
+  [terms]
+  (let [index (compile-switch (first terms))
+        arguments (filter (fn [i] (= :argument (first i))) terms)
+        arguments (map compile-switch arguments)]
+    [index arguments]
+    (fn [m x]
+      (let [f (get m index)]
+        (apply f (cons x arguments))))))
+
+(defn compile-switch
+  [[key & terms]]
+  (condp = key
+    :field (compile-field terms)
+    :constant (apply str terms)
+    :template (compile-switch (first (rest (butlast terms))))
+    :expression (compile-expression terms)
+    :accessor (compile-accessor terms)
+    :function (compile-function terms)
+    :index (apply str terms)
+    :argument (apply str terms)
+    terms))
+
+(defn apply-context
+  [m f]
+  (if (fn? f)
+    (f m)
+    f))
+
+(defn compile-top
+  [field]
+  (let [parse (field-parser field)
+        compiled (compile-switch parse)]
+    (fn [m]
+      (let [applied (map (partial apply-context m) compiled)]
+        (apply str applied)))))

--- a/src/protograph/compile.clj
+++ b/src/protograph/compile.clj
@@ -32,14 +32,17 @@
         functions (map compile-switch functions)]
     [accessor functions]
     (fn [m]
-      (apply comp (reverse (map (fn [f] (partial f m)) functions))))))
+      (let [applied (map (fn [f] (partial f m)) functions)
+            composite (apply comp (reverse (cons accessor applied)))]
+        (composite m)))))
 
 (defn compile-accessor
   [terms]
   (let [indexes (filter (fn [i] (= :index (first i))) terms)
         indexes (map compile-switch indexes)]
     [:get-in :m indexes]
-    (fn [m] (get-in m indexes))))
+    (fn [m]
+      (get-in m indexes))))
 
 (defn compile-function
   [terms]
@@ -66,7 +69,7 @@
 
 (defn apply-context
   [m f]
-  (if (fn? f)
+  (if (ifn? f)
     (f m)
     f))
 

--- a/src/protograph/compile.clj
+++ b/src/protograph/compile.clj
@@ -3,7 +3,7 @@
    [clojure.string :as string]
    [instaparse.core :as parse]))
 
-(def parser-spec
+(def field-spec
   "field = constant (template constant)*
    constant = #'[^{}]'*
    template = '{{' expression '}}'
@@ -17,7 +17,7 @@
    pipe = '|'")
 
 (def field-parser
-  (parse/parser parser-spec))
+  (parse/parser field-spec))
 
 (declare compile-switch)
 
@@ -73,10 +73,19 @@
     (f m)
     f))
 
+(defn expression?
+  [compiled]
+  (and
+   (= 3 (count compiled))
+   (empty? (first compiled))
+   (empty? (last compiled))))
+
 (defn compile-top
   [field]
   (let [parse (field-parser field)
         compiled (compile-switch parse)]
     (fn [m]
       (let [applied (map (partial apply-context m) compiled)]
+        (if (expression? applied)
+          (second applied))
         (apply str applied)))))

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -15,15 +15,19 @@
 
 (defn convert-int
   [n]
-  (try
-    (Long/parseLong n)
-    (catch Exception e 0)))
+  (if (string? n)
+    (try
+      (Long/parseLong n)
+      (catch Exception e 0))
+    n))
 
 (defn convert-float
   [r]
-  (try
-    (Double/parseDouble r)
-    (catch Exception e 0.0)))
+  (if (string? r)
+    (try
+      (Double/parseDouble r)
+      (catch Exception e 0.0))
+    r))
 
 (defn template-or
   [m & is]

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -158,7 +158,6 @@
                    (fn [in]
                      (process directive (assoc message "_index" in)))
                    series)]
-        (log/info "series" series)
         (post after)))
     (process directive (assoc message "_self" message))))
 

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -176,7 +176,8 @@
    (process-index
     (partial
      process-entity
-     [:gid :fromLabel :from :label :toLabel :to]
+     ;; [:gid :fromLabel :from :label :toLabel :to]
+     [:gid :from :label :to]
      edge-fields)
     (partial reduce into [])
     protograph
@@ -261,9 +262,9 @@
 (defn compile-edge
   [edge]
   (-> edge
-      (update :fromLabel compile/compile-top)
+      ;; (update :fromLabel compile/compile-top)
       (update :label compile/compile-top)
-      (update :toLabel compile/compile-top)
+      ;; (update :toLabel compile/compile-top)
       (update :from compile/compile-top)
       (update :to compile/compile-top)
       (update :index compile?)

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -36,10 +36,13 @@
      (drop-while empty? out))))
 
 (defn truncate
-  [s n]
-  (if (> (count s) n)
-    (.substring s 0 n)
-    s))
+  [s n?]
+  (try
+    (let [n (Integer/parseInt n?)]
+      (if (> (count s) n)
+        (.substring s 0 n)
+        s))
+    (catch Exception e s)))
 
 (def defaults
   {"each" (fn [s k] (mapv #(get % k) s))

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -35,11 +35,18 @@
     (first
      (drop-while empty? out))))
 
+(defn truncate
+  [s n]
+  (if (> (count s) n)
+    (.substring s 0 n)
+    s))
+
 (def defaults
   {"each" (fn [s k] (mapv #(get % k) s))
    "flatten" flatten
    "split" (fn [s d] (string/split s (re-pattern d)))
    "or" template-or
+   "truncate" truncate
    "sort" sort
    "join" (fn [l d] (string/join d l))
    "float" convert-float

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -57,7 +57,7 @@
 (defn evaluate-template
   [template context]
   (let [context (merge defaults context)]
-    (template/render context)))
+    (template/render template context)))
 
 (defn evaluate-map
   [m context]

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -65,16 +65,13 @@
    {}
    (map
     (fn [[k template]]
-      (let [press
-            (try
-              (evaluate-template template context)
-              (catch Exception e (log/info "failed" k template context)))
+      (let [press (evaluate-template template context)
             [key type] (string/split (name k) dot)
             outcome (condp = type
                       "int" (convert-int press)
                       "float" (convert-float press)
                       press)]
-        [key outcome]))
+        [(keyword key) outcome]))
     m)))
 
 (defn render-template

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -39,6 +39,8 @@
    "flatten" flatten
    "split" (fn [s d] (string/split s (re-pattern d)))
    "or" template-or
+   "sort" sort
+   "join" (fn [l d] (string/join d l))
    "float" convert-float
    "name" name
    "first" first
@@ -88,7 +90,10 @@
       (let [press
             (try
               (render-template template context)
-              (catch Exception e (log/info "failed" k template context)))
+              (catch Exception e
+                (do
+                  (log/info "failed" k template)
+                  (.printStackTrace e))))
             [key type] (string/split (name k) dot)
             outcome (condp = type
                       "int" (convert-int press)

--- a/src/protograph/template.clj
+++ b/src/protograph/template.clj
@@ -152,12 +152,14 @@
 
 (defn process-index
   [process post {:keys [label index] :as directive} message]
-  (if-let [series (render-template index message)]
-    (let [after (mapv
-                 (fn [in]
-                   (process directive (assoc message "_index" in)))
-                 series)]
-      (post after))
+  (if index
+    (if-let [series (render-template index message)]
+      (let [after (mapv
+                   (fn [in]
+                     (process directive (assoc message "_index" in)))
+                   series)]
+        (log/info "series" series)
+        (post after)))
     (process directive (assoc message "_self" message))))
 
 (defn process-edge
@@ -231,6 +233,11 @@
       [k (compile/compile-top v)])
     m)))
 
+(defn compile?
+  [template]
+  (if template
+    (compile/compile-top template)))
+
 (defn compile-edge
   [edge]
   (-> edge
@@ -239,7 +246,7 @@
       (update :toLabel compile/compile-top)
       (update :from compile/compile-top)
       (update :to compile/compile-top)
-      (update :index compile/compile-top)
+      (update :index compile?)
       (update :data compile-map)))
 
 (defn compile-vertex
@@ -247,13 +254,13 @@
   (-> vertex
       (update :label compile/compile-top)
       (update :gid compile/compile-top)
-      (update :index compile/compile-top)
+      (update :index compile?)
       (update :data compile-map)))
 
 (defn compile-inner
   [inner]
   (-> inner
-      (update :index compile/compile-top)
+      (update :index compile?)
       (update :path compile/compile-top)))
 
 (defn compile-entry


### PR DESCRIPTION
This PR introduces a PEG for protograph templates which parses template strings into an AST, then walks the tree to compile them into native functions.

On protograph load during startup, this compilation is run on the input protograph yaml file and then the native functions are applied during the actual protograph process.

In my tests this increases the speed of protograph transformations by >6x over the template library we were using before.