### PR TITLE
Refactor command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,9 @@ Either way, start by downloading the [latest release](https://github.com/bmeg/pr
 
 To run Protograph on a directory of input files, use the `--input` and `--output` options, along with the path to your `protograph.yaml` under `--protograph`:
 
-    java -jar protograph.jar --protograph path/to/protograph.yaml --input /path/to/input/messages.Label.json --output /path/to/output/with/file.prefix
+    java -jar protograph.jar --protograph path/to/protograph.yaml \\
+                             --input /path/to/input/messages.Label.json \\
+                             --output /path/to/output/with/file.prefix
 
 Once processing is complete, it will output two files of the form:
 
@@ -422,7 +424,8 @@ depending on what you passed to `--output`. If you know all messages will have a
 
 To run Protograph in Kafka mode you must have access to a Kafka node with some topics to import. 
 
-    java -jar protograph.jar --protograph path/to/protograph.yaml --topic "topic1 topic2 topic3"
+    java -jar protograph.jar --protograph path/to/protograph.yaml \\
+                             --topic "topic1 topic2 topic3"
 
 This will by default output to the Kafka topics `protograph.Vertex` and `protograph.Edge`. To change the prefix for these topics pass in something under the `--prefix` key:
 
@@ -431,13 +434,16 @@ This will by default output to the Kafka topics `protograph.Vertex` and `protogr
 
 If you need to change the kafka host, pass it in under `--kafka`:
 
-    java -jar protograph.jar --protograph path/to/protograph.yaml --kafka 10.96.11.82:9092 --topic "topic1 topic2 topic3"
+    java -jar protograph.jar --protograph path/to/protograph.yaml \\
+                             --kafka 10.96.11.82:9092 \\
+                             --topic "topic1 topic2 topic3"
 
 # generating dot files
 
 You can also use protograph to generate a dot file representing the connections between all the node types. To do so, run the following command:
 
-    java -cp protograph.jar clojure.main -m protograph.dot --protograph path/to/protograph.yaml --output path/to/output.dot
+    java -cp protograph.jar clojure.main -m protograph.dot --protograph path/to/protograph.yaml \\
+                                                           --output path/to/output.dot
 
 Then you can generate a png representing the graph using the following command (assuming you have `graphviz` installed):
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,10 @@
                  [io.forward/yaml "1.0.6"]
                  [com.taoensso/timbre "4.8.0"]
                  [clojurewerkz/propertied "1.2.0"]
-                 [org.apache.kafka/kafka_2.11 "0.10.0.1"]]
+                 [org.apache.kafka/kafka_2.11 "0.10.0.1"]
+                 [clojure-future-spec "1.9.0-beta4"]]
+  :profiles {:dev {:plugins [[venantius/yagni "0.1.4"]
+                             [lein-hiera "1.0.0"]]}}
   :repositories [["sonatype snapshots"
                   "https://oss.sonatype.org/content/repositories/snapshots"]
                  ["sonatype releases"

--- a/src/protograph/kafka.clj
+++ b/src/protograph/kafka.clj
@@ -12,15 +12,15 @@
    [kafka.utils ZkUtils]
    [kafka.admin AdminUtils]))
 
-(def string-serializer
+(def ^:private string-serializer
   {"key.serializer" "org.apache.kafka.common.serialization.StringSerializer"
    "value.serializer" "org.apache.kafka.common.serialization.StringSerializer"})
 
-(def string-deserializer
+(def ^:private string-deserializer
   {"key.deserializer" "org.apache.kafka.common.serialization.StringDeserializer"
    "value.deserializer" "org.apache.kafka.common.serialization.StringDeserializer"})
 
-(def consumer-defaults
+(def ^:private consumer-defaults
   (merge
    string-deserializer
    {;; "auto.offset.reset" "earliest"
@@ -150,9 +150,8 @@
 
 (defn dir->files
   [path]
-  (filter
-   #(.isFile %)
-   (file-seq (io/file path))))
+  (filter #(.isFile %)
+          (file-seq (io/file path))))
 
 (defn dir->streams
   [out path]
@@ -189,6 +188,7 @@
     (dir->streams spout path)))
 
 (def parse-args
+  ;; NOTE: might be useful to be able to specify host and port separately
   [["-k" "--kafka KAFKA" "host for kafka server"
     :default "localhost:9092"]
    ["-t" "--topic TOPIC" "kafka topic"]

--- a/src/protograph/utils.clj
+++ b/src/protograph/utils.clj
@@ -1,0 +1,20 @@
+(ns protograph.utils
+  "Common utilities"
+  (:require [clojure.string :as str]))
+
+(defn format-parse-opts
+  "pprint parse options"
+  [parse-opts]
+  (->> parse-opts
+       (map #(str/join " :: " (take 3 %)))
+       (str/join "\n")))
+
+(defn report-parse-errors
+  "pprint parse errors caught by tools.cli validation predicates"
+  [errors]
+  {:pre [(vector? errors)]}
+  (let [error-report
+        (str "The following errors occurred while parsing your command:\n"
+             (str/join \newline errors))]
+    (println error-report)
+    (System/exit 1)))

--- a/src/protograph/validation.clj
+++ b/src/protograph/validation.clj
@@ -1,0 +1,66 @@
+(ns protograph.validation
+  (:require
+   [clojure.spec.alpha :as spec]
+   [clojure.future :refer [boolean?]]
+   [yaml.core :as yaml]
+   [clojure.walk :as walk]))
+
+(spec/def ::to
+  string?)
+
+(spec/def ::from
+  string?)
+
+(spec/def ::toLabel
+  string?)
+
+(spec/def ::fromLabel
+  string?)
+
+(spec/def ::index
+  string?)
+
+(spec/def ::label
+  string?)
+
+(spec/def ::path
+  string?)
+
+(spec/def ::gid
+  string?)
+
+(spec/def ::merge
+  boolean?)
+
+(spec/def ::filter
+  (spec/coll-of string?))
+
+(spec/def ::fields
+  (spec/coll-of string?))
+
+(spec/def ::splice
+  (spec/coll-of string?))
+
+(spec/def ::inner
+  (spec/coll-of
+   (spec/keys :req-un [::index ::path ::label])))
+
+(spec/def ::data
+  (spec/map-of keyword? string?))
+
+(spec/def ::edges
+  (spec/coll-of
+   (spec/keys :req-un [::fromLabel ::toLabel ::label ::from ::to]
+              :opt-un [::index ::fields ::filter ::merge])))
+
+(spec/def ::vertexes
+  (spec/coll-of
+   (spec/keys :req-un [::label ::gid]
+              :opt-un [::filter ::fields ::splice ::merge ::data])))
+
+(spec/def ::entry
+  (spec/keys :req-un [::label]
+             :opt-un [::inner ::edges ::vertexes]))
+
+(spec/def ::protograph
+  (spec/coll-of ::entry))


### PR DESCRIPTION
This commit introduces some light refactoring to protograph's cli. Poorly formed or incomplete sets of arguments are met with more descriptive feedback. In addition, a modest amount of input data validation is added.

This commit also includes some peripheral changes, including privatizing functions and deleting unused code.

Closes #4, #10, #11, #12.

@prismofeverything: Please don't merge these changes yet. I'm currently doing some additional testing. Please comment on these modifications when you get the chance to do so.